### PR TITLE
[FIX] Remove trailing comma to avoid error

### DIFF
--- a/fleet_car_workshop/models/dashboard.py
+++ b/fleet_car_workshop/models/dashboard.py
@@ -100,7 +100,7 @@ class CarVehicle(osv.osv):
                               track_visibility='onchange',default='open', copy=False)
 
     date_start = fields.Date(string='Start Date')
-    date = fields.Date(string='Expiration Date', select=True, track_visibility='onchange'),
+    date = fields.Date(string='Expiration Date', select=True, track_visibility='onchange')
     use_tasks = fields.Boolean(string='Tasks', default=True)
     image_medium = fields.Binary(string="Logo (medium)")
 


### PR DESCRIPTION
Actual error is:
ERROR ? odoo.models: Trailing comma after field definition: <class 'odoo.addons.fleet_car_workshop.models.dashboard.CarVehicle'>.date

Can be avoided removing the trailing comma