### PR TITLE
[FIX] models importation is commented out.

### DIFF
--- a/cron_failure_notification/__init__.py
+++ b/cron_failure_notification/__init__.py
@@ -19,4 +19,5 @@
 #    GENERAL PUBLIC LICENSE (LGPL v3) along with this program.
 #    If not, see <http://www.gnu.org/licenses/>.
 #
-##############################################################################import models
+##############################################################################
+import models


### PR DESCRIPTION
Hello CybroOdoo team,

I found the importation line is commented. It's causing error when installing the module.
May my pull request help you.

Thanks.