### PR TITLE
[FIX] Fix attribute "digits" on "discount" fields.

### DIFF
--- a/sale_discount_total/views/account_invoice_view.xml
+++ b/sale_discount_total/views/account_invoice_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="account.invoice_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='discount']" position="attributes">
-                    <attribute name="digits">(16, 2)</attribute>
+                    <attribute name="digits">[16, 2]</attribute>
                 </xpath>
                 <xpath expr="//field[@name='amount_untaxed']" position="after">
                         <field name="amount_discount"/>
@@ -32,7 +32,7 @@
             <field name="inherit_id" ref="account.view_invoice_line_tree"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='discount']" position="attributes">
-                    <attribute name="digits">(16, 2)</attribute>
+                    <attribute name="digits">[16, 2]</attribute>
                 </xpath>
             </field>
         </record>

--- a/sale_discount_total/views/sale_view.xml
+++ b/sale_discount_total/views/sale_view.xml
@@ -15,7 +15,7 @@
                      <attribute name ="states">draft,sent,sale,waiting</attribute>
                 </xpath>
                 <!--<xpath expr="//tree/field[@name='discount']" position="replace">-->
-                    <!--<field name="discount" class="oe_inline" digits="(16, 2)"/> %%-->
+                    <!--<field name="discount" class="oe_inline" digits="[16, 2]"/> %%-->
                 <!--</xpath>-->
                 <xpath expr="//group[@name='sale_total']" position="replace">
                     <group col="4">


### PR DESCRIPTION
I think this commit doesn't need any kind of description.

Simply, this commit solve the following problem:

```
Uncaught SyntaxError: Unexpected token ( in JSON at position 0
    at JSON.parse (<anonymous>)
    at Class.init (basic_fields.js:829)
    at Class.prototype.(:8069/anonymous function) [as init] (http://localhost:8069/web/static/src/js/core/class.js:90:38)
    at new Class (class.js:107)
    at Class._renderFieldWidget (basic_renderer.js:532)
    at Class._renderBodyCell (list_renderer.js:282)
    at list_editable_renderer.js:312
    at Function._.each._.forEach (underscore.js:145)
    at Class.setRowMode (list_editable_renderer.js:310)
    at Class._onEditLine (relational_fields.js:1034)
```