### PR TITLE
[FIX] Fix the double SO confirmation due to hysterical clicks on the "Confirm" button. 🤪

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# IDEs files and dirs
+#
+.idea/
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/sale_discount_total/__manifest__.py
+++ b/sale_discount_total/__manifest__.py
@@ -22,7 +22,7 @@
 
 {
     'name': 'Sale Discount on Total Amount',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Sales Management',
     'summary': "Discount on Total in Sale and Invoice With Discount Limit and Approval",
     'author': 'Cybrosys Techno Solutions',


### PR DESCRIPTION
Odoo SA has released this fix to the source code of Odoo in [this commit](https://github.com/odoo/odoo/commit/79a7d58a1c14f37f2ec1abc1f6f3fcf55bcd30c4).

If you continue to click hysterically on the "Confirm" button, this can cause a double confirmation of the same Sales Order due to a slow refresh of the UI.  
This PR fix the problem.