### PR TITLE
[10.0][inventory_barcode_scanning] Fix check when barcode is empty

### DIFF
--- a/inventory_barcode_scanning/models/stock_picking.py
+++ b/inventory_barcode_scanning/models/stock_picking.py
@@ -18,7 +18,8 @@ class StockPicking(models.Model):
             raise Warning('No product is available for this barcode')
         if self.barcode and self.pack_operation_product_ids:
             for line in self.pack_operation_product_ids:
-                if line.product_id.barcode == self.barcode:
+                if line.product_id.barcode and \
+                        line.product_id.barcode == self.barcode:
                     line.qty_done += 1
                     self.barcode = None
                     match = True


### PR DESCRIPTION
Fix the condition when a product line doesn't have a barcode and was anyway increasing the quantity