### PR TITLE
13.0 [FIX] base_accounting_kit: credit_limit error self.type

### DIFF
--- a/base_accounting_kit/models/credit_limit.py
+++ b/base_accounting_kit/models/credit_limit.py
@@ -78,8 +78,7 @@ class SaleOrder(models.Model):
     def _action_confirm(self):
         """To check the selected customers due amount is exceed than
         blocking stage"""
-        pay_type = ['out_invoice', 'out_refund', 'out_receipt']
-        if self.partner_id.active_limit and self.type in pay_type \
+        if self.partner_id.active_limit \
                 and self.partner_id.enable_credit_limit:
             if self.due_amount >= self.partner_id.blocking_stage:
                 if self.partner_id.blocking_stage != 0:


### PR DESCRIPTION
In partner go to sale.order button and create a new order. When you try to confirm it, an error generated "self.type not exist in sale.order". Sale order generate only out_invoice, this arg is until.