### PR TITLE
[FIX] 12.0 task_deadline_reminder fix the task url in the mail template

### DIFF
--- a/task_deadline_reminder/__manifest__.py
+++ b/task_deadline_reminder/__manifest__.py
@@ -19,7 +19,7 @@
 
 {
     'name': "Task Deadline Reminder",
-    'version': "12.0.1.0.0",
+    'version': "12.0.2.0.0",
     'author': 'Cybrosys Techno Solutions',
     'company': 'Cybrosys Techno Solutions',
     'website': 'https://www.cybrosys.com',

--- a/task_deadline_reminder/data/deadline_reminder_action_data.xml
+++ b/task_deadline_reminder/data/deadline_reminder_action_data.xml
@@ -32,7 +32,7 @@
                                         <td><span>${object.project_id.name}</span></td>
                                         <td><span>${object.date_deadline}</span></td>
                                         <td><span>${object.user_id.name}</span></td>
-                                        <td><a href=/web/login/>View Now</a></td>
+                                        <td><a href=${object.get_task_deadline_reminder_url()}>View Now</a></td>
                                     </tr>
                              </tbody>
                        </table>

--- a/task_deadline_reminder/i18n/es.po
+++ b/task_deadline_reminder/i18n/es.po
@@ -1,0 +1,104 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* task_deadline_reminder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-17 12:35+0000\n"
+"PO-Revision-Date: 2022-02-17 12:35+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: task_deadline_reminder
+#: model:mail.template,body_html:task_deadline_reminder.email_template_edi_deadline_reminder
+msgid "\n"
+"                <div class=\"page\">\n"
+"                    <div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"                        <p>Hello ${object.user_id.name},</p>\n"
+"                        <p> This Email Is To Remind  You That You Have Task As  Below Listed Which Are Due On Today. </p>\n"
+"                    </div>\n"
+"                    <div>\n"
+"                       <table class=\"table table-condensed\">\n"
+"                             <thead>\n"
+"                                <tr>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Task</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Project</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Deadline</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Assigned To</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Link</th>\n"
+"                                </tr>\n"
+"                             </thead>\n"
+"                             <tbody>\n"
+"                                    <tr>\n"
+"                                        <td><span>${object.name}</span></td>\n"
+"                                        <td><span>${object.project_id.name}</span></td>\n"
+"                                        <td><span>${object.date_deadline}</span></td>\n"
+"                                        <td><span>${object.user_id.name}</span></td>\n"
+"                                        <td><a href=${object.get_task_deadline_reminder_url()}>View Now</a></td>\n"
+"                                    </tr>\n"
+"                             </tbody>\n"
+"                       </table>\n"
+"                    </div>\n"
+"                </div>\n"
+"                \n"
+"            "
+msgstr "\n"
+"                <div class=\"page\">\n"
+"                    <div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"                        <p>Hola ${object.user_id.name},</p>\n"
+"                        <p> Este correo electrónico es para recordarle que tiene una tarea con fecha límite hoy.</p>\n"
+"                    </div>\n"
+"                    <div>\n"
+"                       <table class=\"table table-condensed\">\n"
+"                             <thead>\n"
+"                                <tr>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Tarea</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Proyecto</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Fecha límite</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Asignada a</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Acceso</th>\n"
+"                                </tr>\n"
+"                             </thead>\n"
+"                             <tbody>\n"
+"                                    <tr>\n"
+"                                        <td><span>${object.name}</span></td>\n"
+"                                        <td><span>${object.project_id.name}</span></td>\n"
+"                                        <td><span>${object.date_deadline}</span></td>\n"
+"                                        <td><span>${object.user_id.name}</span></td>\n"
+"                                        <td><a href=${object.get_task_deadline_reminder_url()}>Ver tarea</a></td>\n"
+"                                    </tr>\n"
+"                             </tbody>\n"
+"                       </table>\n"
+"                    </div>\n"
+"                </div>\n"
+"                \n"
+"            "
+
+#. module: task_deadline_reminder
+#: model:ir.model.fields,field_description:task_deadline_reminder.field_project_task__task_reminder
+msgid "Reminder"
+msgstr "Recordatorio"
+
+#. module: task_deadline_reminder
+#: model:ir.model,name:task_deadline_reminder.model_project_task
+msgid "Task"
+msgstr "Tarea"
+
+#. module: task_deadline_reminder
+#: model:ir.actions.server,name:task_deadline_reminder.availability_create_cron_ir_actions_server
+#: model:ir.cron,cron_name:task_deadline_reminder.availability_create_cron
+#: model:ir.cron,name:task_deadline_reminder.availability_create_cron
+msgid "Task DeadLine Reminder"
+msgstr "Recordatorio de la fecha límite de la tarea"
+
+#. module: task_deadline_reminder
+#: model:mail.template,subject:task_deadline_reminder.email_template_edi_deadline_reminder
+msgid "Today Due Task -${object.date_deadline or 'n/a' }"
+msgstr "Fecha límite de tarea -${object.date_deadline or 'n/a' }"
+

--- a/task_deadline_reminder/i18n/eu_ES.po
+++ b/task_deadline_reminder/i18n/eu_ES.po
@@ -1,0 +1,104 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* task_deadline_reminder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-17 12:42+0000\n"
+"PO-Revision-Date: 2022-02-17 12:42+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: task_deadline_reminder
+#: model:mail.template,body_html:task_deadline_reminder.email_template_edi_deadline_reminder
+msgid "\n"
+"                <div class=\"page\">\n"
+"                    <div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"                        <p>Hello ${object.user_id.name},</p>\n"
+"                        <p> This Email Is To Remind  You That You Have Task As  Below Listed Which Are Due On Today. </p>\n"
+"                    </div>\n"
+"                    <div>\n"
+"                       <table class=\"table table-condensed\">\n"
+"                             <thead>\n"
+"                                <tr>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Task</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Project</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Deadline</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Assigned To</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Link</th>\n"
+"                                </tr>\n"
+"                             </thead>\n"
+"                             <tbody>\n"
+"                                    <tr>\n"
+"                                        <td><span>${object.name}</span></td>\n"
+"                                        <td><span>${object.project_id.name}</span></td>\n"
+"                                        <td><span>${object.date_deadline}</span></td>\n"
+"                                        <td><span>${object.user_id.name}</span></td>\n"
+"                                        <td><a href=${object.get_task_deadline_reminder_url()}>View Now</a></td>\n"
+"                                    </tr>\n"
+"                             </tbody>\n"
+"                       </table>\n"
+"                    </div>\n"
+"                </div>\n"
+"                \n"
+"            "
+msgstr "\n"
+"                <div class=\"page\">\n"
+"                    <div style=\"font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; \">\n"
+"                        <p>Kaixo ${object.user_id.name},</p>\n"
+"                        <p> Mezu elektroniko honen bidez gogorarazi nahi dizugu ataza baten epe muga gaur dela. </p>\n"
+"                    </div>\n"
+"                    <div>\n"
+"                       <table class=\"table table-condensed\">\n"
+"                             <thead>\n"
+"                                <tr>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Ataza</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Proiektua</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Epemuga</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Arduraduna</th>\n"
+"                                    <th style=\"background-color:#9b9da0 !important;\">Esteka</th>\n"
+"                                </tr>\n"
+"                             </thead>\n"
+"                             <tbody>\n"
+"                                    <tr>\n"
+"                                        <td><span>${object.name}</span></td>\n"
+"                                        <td><span>${object.project_id.name}</span></td>\n"
+"                                        <td><span>${object.date_deadline}</span></td>\n"
+"                                        <td><span>${object.user_id.name}</span></td>\n"
+"                                        <td><a href=${object.get_task_deadline_reminder_url()}>Ikusi orain</a></td>\n"
+"                                    </tr>\n"
+"                             </tbody>\n"
+"                       </table>\n"
+"                    </div>\n"
+"                </div>\n"
+"                \n"
+"            "
+
+#. module: task_deadline_reminder
+#: model:ir.model.fields,field_description:task_deadline_reminder.field_project_task__task_reminder
+msgid "Reminder"
+msgstr "Gogorarazlea"
+
+#. module: task_deadline_reminder
+#: model:ir.model,name:task_deadline_reminder.model_project_task
+msgid "Task"
+msgstr "Ataza"
+
+#. module: task_deadline_reminder
+#: model:ir.actions.server,name:task_deadline_reminder.availability_create_cron_ir_actions_server
+#: model:ir.cron,cron_name:task_deadline_reminder.availability_create_cron
+#: model:ir.cron,name:task_deadline_reminder.availability_create_cron
+msgid "Task DeadLine Reminder"
+msgstr "Atazaren mugaeguna gogoraraztea"
+
+#. module: task_deadline_reminder
+#: model:mail.template,subject:task_deadline_reminder.email_template_edi_deadline_reminder
+msgid "Today Due Task -${object.date_deadline or 'n/a' }"
+msgstr "Atazaren mugaeguna -${object.date_deadline or 'n/a' }"
+

--- a/task_deadline_reminder/models/deadline_reminder.py
+++ b/task_deadline_reminder/models/deadline_reminder.py
@@ -34,4 +34,6 @@ class DeadLineReminder(models.Model):
                         msg_id.send()
         return True
 
-
+    @api.multi
+    def get_task_deadline_reminder_url(self):
+        return self.get_base_url() + self._get_share_url(redirect=True)


### PR DESCRIPTION
In the e-mail template, the "View Now" has a fixed URL "/web/login" and when you open it with an e-mail browser it redirects you to the login view.

The aim of this commit is to fix this URL ant redirect the user to the task form view instead to the login page. 