### PR TITLE
[UPDT] fix typo

### DIFF
--- a/subscription_package/__manifest__.py
+++ b/subscription_package/__manifest__.py
@@ -22,7 +22,7 @@
 
 {
     'name': 'Subscription Management For Community',
-    'Version': '15.0.1.0.0',
+    'version': '15.0.1.0.0',
     'summary': 'Subscription Package Management Module For Odoo15 Community',
     'description': 'Subscription Package Management Module For Odoo15 Community',
     'category': 'Sales',


### PR DESCRIPTION
fix a minor typo inside `__manifest.py__` to make it consistent with other addons