### PR TITLE
[FIX] prevent error when return with mixed lines

### DIFF
--- a/product_return_pos/models/pos_return.py
+++ b/product_return_pos/models/pos_return.py
@@ -64,7 +64,7 @@ class PosOrderReturn(models.Model):
             qty = 0
             for uptd in updated_lines:
                 line = self.env['pos.order.line'].search([('order_id', '=', parent_order.id),
-                                                           ('id', '=', uptd[2]['line_id'])], limit=1)
+                                                           ('id', '=', uptd[2].get('line_id', False))], limit=1)
                 if line:
                     line.returned_qty += -(uptd[2]['qty'])
             for line in parent_order.lines:


### PR DESCRIPTION
When creating a return and adding a new product to that return (exchange scenario), an error is raised because the new line is in a returned order but is not itself a return.

This simpl fix prevent that error.