### PR TITLE
Update account_payment_view.xml

### DIFF
--- a/base_accounting_kit/views/account_payment_view.xml
+++ b/base_accounting_kit/views/account_payment_view.xml
@@ -23,6 +23,14 @@
                 <field name="check_number"
                        attrs="{'invisible': ['|', ('payment_method_code', 'not in', ['check_printing','pdc']), ('check_number', '=', 0)]}"/>
             </xpath>
+        </field>
+    </record>
+    
+    <record id="view_account_payment_form_inherited" model="ir.ui.view">
+        <field name="name">account.payment.form.inherited</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form"/>
+        <field name="arch" type="xml">
             <xpath expr="//field[@name='date']" position="after">
                 <field name="effective_date"
                        attrs="{'invisible': [('payment_method_code', '!=', 'pdc')],


### PR DESCRIPTION
fix effective_date field error while modules updates
rewrited account_check_printing.view_account_payment_form_inherited adds effective_date
when this fields in account_check_printing.view_account_payment_form_inherited adds effective_date it leads to error.

field  effective_date should be add though new view