### PR TITLE
In base_accounting_kit/models/payment_matching.py (Odoo 14) there is …

### DIFF
--- a/base_accounting_kit/models/payment_matching.py
+++ b/base_accounting_kit/models/payment_matching.py
@@ -1131,7 +1131,7 @@ class AccountBankStatementLine(models.Model):
             raise UserError(_('Operation not allowed. Since your statement line already received a number (%s), you cannot reconcile it entirely with existing journal entries otherwise it would make a gap in the numbering. You should book an entry and make a regular revert of it in case you want to cancel it.')% (self.move_name))
 
         # create the res.partner.bank if needed
-        if self.account_number and self.partner_id and not self.bank_account_id:
+        if self.account_number and self.partner_id and not self.partner_bank_id:
             # Search bank account without partner to handle the case the res.partner.bank already exists but is set
             # on a different partner.
             self.partner_bank_id = self._find_or_create_bank_account()


### PR DESCRIPTION
…no bank_account_id in the bank.statement.line  it is supposed to be partner_bank_id.

This bug is similar to the one documented here:  https://github.com/OCA/account-reconcile/pull/380

It is easily noticed / repeatable if you are trying to use camt.053 files which contain IBAN number of the partner involved in a payment.  The conditional will get hit, and you will always get the Error that bank_account_id is not part of the bank.statement.line model.  Which is indeed the case.  It should be partner_bank_id.