### PR TITLE
[FIX] *: Warning raised by typo in manifest key: "license"

### DIFF
--- a/odoo_picking_order_line_views/__manifest__.py
+++ b/odoo_picking_order_line_views/__manifest__.py
@@ -27,7 +27,7 @@
     'maintainer': 'Cybrosys Techno Solutions',
     'website': "https://www.cybrosys.com",
     'category': 'Sales',
-    'licence': 'LGPL-3',
+    'license': 'LGPL-3',
     'depends': ['base', 'sale', 'stock', 'sale_management', 'purchase'],
     'data': [
         'views/in_operation_line_views.xml',

--- a/odoo_sale_order_line_views/__manifest__.py
+++ b/odoo_sale_order_line_views/__manifest__.py
@@ -27,7 +27,7 @@
     'maintainer': 'Cybrosys Techno Solutions',
     'website': "https://www.cybrosys.com",
     'category': 'Sales',
-    'licence': 'LGPL-3',
+    'license': 'LGPL-3',
     'depends': ['sale_management'],
     'data': [
         'views/quotation_line_views.xml',

--- a/pos_custom_message/__manifest__.py
+++ b/pos_custom_message/__manifest__.py
@@ -46,7 +46,7 @@
         ],
     },
     'images': ['static/description/banner.jpg'],
-    'licence': 'AGPL-3',
+    'license': 'AGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False,

--- a/website_pre_loader_style/__manifest__.py
+++ b/website_pre_loader_style/__manifest__.py
@@ -47,7 +47,7 @@
         ]
     },
     'images': ['static/description/banner.jpg'],
-    'licence': 'AGPL-3',
+    'license': 'AGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False,


### PR DESCRIPTION
The word 'license' can be written "licence" too but odoo expects
"license".

The fallowing warning was being raised, even when the module was not
installed.

WARNING ? odoo.modules.module: Missing `license` key in manifest for
'website_pre_loader_style', defaulting to LGPL