### PR TITLE
added _description to insta_feed_snippet

### DIFF
--- a/insta_feed_snippet/models/insta_post.py
+++ b/insta_feed_snippet/models/insta_post.py
@@ -6,6 +6,7 @@ from odoo.exceptions import UserError
 
 class InstaPost(models.Model):
     _name = 'insta.post'
+    _description = 'Instagram Post'
 
     name = fields.Char(string="Media ID")
     caption = fields.Char("Caption")

--- a/insta_feed_snippet/models/insta_profile.py
+++ b/insta_feed_snippet/models/insta_profile.py
@@ -7,6 +7,7 @@ from odoo.exceptions import UserError
 
 class InstaProfile(models.Model):
     _name = 'insta.profile'
+    _description = 'Instagram Profile'
 
     name = fields.Char(string="Name", readonly=True)
     access_token = fields.Char("Access Token")


### PR DESCRIPTION
The missing _description constant of the newly created models insta.post and insta.profile create recurring errors in the logs.

This PR adds the missing tag and resolves the issue