### PR TITLE
Update create method overwrite in hide_menu_user (res.user)

### DIFF
--- a/hide_menu_user/models/res_user.py
+++ b/hide_menu_user/models/res_user.py
@@ -26,13 +26,13 @@ from odoo import models, fields, api
 class HideMenuUser(models.Model):
     _inherit = 'res.users'
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         """
         Else the menu will be still hidden even after removing from the list
         """
         self.clear_caches()
-        return super(HideMenuUser, self).create(vals)
+        return super(HideMenuUser, self).create(vals_list)
 
     def write(self, vals):
         """


### PR DESCRIPTION
The module throws an error in the logs, because in Odoo 16 the re.users model uses batch creation of records:

`The model odoo.addons.hide_menu_user.models.res_user is not overriding the create method in batch`

Steps to fix:
1. Added correct decorator "@api.model_create_multi"
2. renamed parameter "vals" to "vals_list" to emphasize that it is a list of vals for a list of records to be created
3. Ususally, one would loop over vals_list (for vals in vals_list), but no modifications to vals are done here, to it so it is not necessary in this case.