### PR TITLE
[FIX] removing redefinition of datetime module

### DIFF
--- a/crm_dashboard/models/crm_dashboard.py
+++ b/crm_dashboard/models/crm_dashboard.py
@@ -20,7 +20,6 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 #
 #############################################################################
-import datetime
 import calendar
 
 from odoo import models, fields, api


### PR DESCRIPTION
Currently at version `16.0.1.0.0` in the `model/crm_dashboard.py` datetime module is getting import 2 times.

>Before:
```
import datetime
import calendar

from odoo import models, fields, api
from odoo.tools import date_utils
from odoo.http import request

from dateutil.relativedelta import relativedelta
from datetime import datetime
```

> After:
```
import calendar

from odoo import models, fields, api
from odoo.tools import date_utils
from odoo.http import request

from dateutil.relativedelta import relativedelta
from datetime import datetime
```