### PR TITLE
[FIX] *: fix license typo in manifests t#71407

### DIFF
--- a/custom_list_view/__manifest__.py
+++ b/custom_list_view/__manifest__.py
@@ -45,7 +45,7 @@
         ]
     },
     'images': ['static/description/banner.png'],
-    'licence': 'LGPL-3',
+    'license': 'LGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False

--- a/delivery_slot/__manifest__.py
+++ b/delivery_slot/__manifest__.py
@@ -51,7 +51,7 @@
         ],
     },
     'images': ['static/description/banner.jpg'],
-    'licence': 'AGPL-3',
+    'license': 'AGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False,

--- a/hide_chatter/__manifest__.py
+++ b/hide_chatter/__manifest__.py
@@ -41,7 +41,7 @@
         ],
     },
     'images': ['static/description/banner.jpg'],
-    'licence': 'AGPL-3',
+    'license': 'AGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False,

--- a/odoo_picking_order_line_views/__manifest__.py
+++ b/odoo_picking_order_line_views/__manifest__.py
@@ -27,7 +27,7 @@
     'maintainer': 'Cybrosys Techno Solutions',
     'website': "https://www.cybrosys.com",
     'category': 'Sales',
-    'licence': 'LGPL-3',
+    'license': 'LGPL-3',
     'depends': ['base', 'sale', 'stock', 'sale_management', 'purchase'],
     'data': [
         'views/in_operation_line_views.xml',

--- a/odoo_sale_order_line_views/__manifest__.py
+++ b/odoo_sale_order_line_views/__manifest__.py
@@ -27,7 +27,7 @@
     'maintainer': 'Cybrosys Techno Solutions',
     'website': "https://www.cybrosys.com",
     'category': 'Sales',
-    'licence': 'LGPL-3',
+    'license': 'LGPL-3',
     'depends': ['sale_management'],
     'data': [
         'views/quotation_line_views.xml',

--- a/package_split/__manifest__.py
+++ b/package_split/__manifest__.py
@@ -38,7 +38,7 @@
         'views/res_config_settings_views.xml',
     ],
     'images': ['static/description/banner.jpg'],
-    'licence': 'AGPL-3',
+    'license': 'AGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False,

--- a/pos_custom_message/__manifest__.py
+++ b/pos_custom_message/__manifest__.py
@@ -46,7 +46,7 @@
         ],
     },
     'images': ['static/description/banner.jpg'],
-    'licence': 'AGPL-3',
+    'license': 'AGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False,

--- a/website_pre_loader_style/__manifest__.py
+++ b/website_pre_loader_style/__manifest__.py
@@ -47,7 +47,7 @@
         ]
     },
     'images': ['static/description/banner.jpg'],
-    'licence': 'AGPL-3',
+    'license': 'AGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False,

--- a/website_social_media_icon_style/__manifest__.py
+++ b/website_social_media_icon_style/__manifest__.py
@@ -44,7 +44,7 @@
         ],
     },
     'images': ['static/description/banner.jpg'],
-    'licence': 'AGPL-3',
+    'license': 'AGPL-3',
     'installable': True,
     'auto_install': False,
     'application': False,


### PR DESCRIPTION
Replace 'licence' with 'license' in manifests that have the typo.