### PR TITLE
Paulius11:17.0]FIX]-hide_menu_user-Raises-ValueError

### DIFF
--- a/hide_menu_user/models/res_users.py
+++ b/hide_menu_user/models/res_users.py
@@ -19,7 +19,7 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 #
 #############################################################################
-from odoo import fields, models
+from odoo import fields, models, Command
 
 
 class ResUsers(models.Model):
@@ -30,14 +30,14 @@ class ResUsers(models.Model):
 
     def write(self, vals):
         """
-         Write method for the ResUsers model.
-         Ensure the menu will not remain hidden after removing it from the list.
-           """
+        Write method for the ResUsers model.
+        Ensure the menu will not remain hidden after removing it from the list.
+        """
         res = super(ResUsers, self).write(vals)
         for record in self:
             for menu in record.hide_menu_ids:
                 menu.write({
-                    'restrict_user_ids': [fields.Command.link(record.id)]
+                'restrict_user_ids': [Command.set([record.id] + [user.id for user in menu.restrict_user_ids])]
                 })
         return res
 


### PR DESCRIPTION
 Expected-singleton-when-installing-hr_-and-other-extensions, when there multiple list of users
This exception is raised, when: 
```
    rslt = super().write(vals)
  File "/custom_addons/hide_menu_user/models/res_users.py", line 37, in write
    menu.restrict_user_ids = [fields.Command.link(self.id)]
  File "/opt/prod-odoo17/odoo/fields.py", line 5140, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: res.users(2, 44, 55, 66, 77..,,)

```