### PR TITLE
[FIX] project_task_attachements: create only modify attach_to task

### DIFF
--- a/project_task_attachments/models/ir_attachment.py
+++ b/project_task_attachments/models/ir_attachment.py
@@ -53,7 +53,8 @@ class IrAttachment(models.Model):
                   'project.project'):
                 vals['project_id'] = vals['res_id']
                 vals['attach_to'] = 'project'
-            else:
+            elif ('task_id' not in vals.keys() and vals['res_model'] ==
+                  'project.task'):
                 vals['task_id'] = vals['res_id']
                 vals['attach_to'] = 'task'
         return super().create(vals_list)


### PR DESCRIPTION
From a new database,
Install project_task_attachments and, only after, install hr_timesheet
A bug occur about 

```
  File "/home/me/git/odoo16/addons/CybroOdoo_CybroAddons/project_task_attachments/models/ir_attachment.py", line 59, in create
    return super().create(vals_list)
```
```
psycopg2.errors.ForeignKeyViolation: insert or update on table "ir_attachment" violates foreign key constraint "ir_attachment_task_id_fkey"
DETAIL:  Key (task_id)=(131) is not present in table "project_task".
```
Thanks for your support!