### PR TITLE
[FIX][16.0] restrict_delivery_method correction

### DIFF
--- a/restrict_delivery_method/__manifest__.py
+++ b/restrict_delivery_method/__manifest__.py
@@ -30,7 +30,7 @@
     'company': 'Cybrosys Techno Solutions',
     'maintainer': 'Cybrosys Techno Solutions',
     'website': 'https://www.cybrosys.com',
-    'depends': ['sale', 'delivery', 'website_sale'],
+    'depends': ['sale', 'delivery', 'website_sale', 'website_sale_delivery'],
     'data': [
         'views/delivery_carrier_views.xml',
         'views/sale_order_views.xml',

--- a/restrict_delivery_method/models/sale_order.py
+++ b/restrict_delivery_method/models/sale_order.py
@@ -51,7 +51,7 @@ class SaleOrder(models.Model):
         """From this function the controller gets the
         restricted methods value"""
         address = self.delivery_method_ids
-        return self.env['delivery.carrier'].sudo().search(
-            [('website_published', '=', True),
-             ('id', 'not in', address.ids)]).available_carriers(
-            address)
+        availables = self._get_delivery_methods()
+        pickables = availables - address
+        
+        return pickables.available_carriers(self.partner_id)


### PR DESCRIPTION
Adds the dependency to "website_sale_delivery" odoo addon in order to use the function _get_delivery_methods() to get the available delivery carriers before applying the restrictions. Otherwise, some unavailable delivery carriers appear as available.