### PR TITLE
standard_price issue when transferring from a company to another

### DIFF
--- a/stock_intercompany_transfer/models/stock_picking.py
+++ b/stock_intercompany_transfer/models/stock_picking.py
@@ -135,6 +135,7 @@ class StockPickingInherit(models.Model):
                         'location_id': location_id,
                         'location_dest_id': location_dest_id,
                         'company_id': company_id.id,
+                        'price_unit': move.product_id.standard_price
                     }
                     self.env['stock.move'].sudo().create(move_vals)
                 if picking_id:


### PR DESCRIPTION

The module works well—thank you very much for contributing to the community!

I did, however, notice a small issue when transferring quantities from one company to another. If the product does not have the same standard price between the two companies, the standard price is not updated.

To resolve this, I suggest filling the price_unit field with the product’s standard price. This ensures that the standard price is correctly updated during the transfer.

I have already tested this functionality, and it works as expected.