### PR TITLE
[FIX] report_attachment_preview: support `close_on_report_download` report option

### DIFF
--- a/report_attachment_preview/static/src/js/report_utils.js
+++ b/report_attachment_preview/static/src/js/report_utils.js
@@ -44,6 +44,9 @@ registry.category("ir.actions.report handlers").add("pdf_report_preview",
     if (["upgrade", "ok"].includes(state)) {
         const url = getReportUrl(action, "pdf");
         window.open(url);
+        if (action.close_on_report_download) {
+            env.services.action.doAction({ type: "ir.actions.act_window_close" });
+        }
         return true;
     } else {
         return _executeReportClientAction(action, options);


### PR DESCRIPTION
Add functionality to close window after report download if specified.

Compare with:
https://github.com/odoo/odoo/blob/12de25f61ba07a4e3379df7bf73174d9b4b0e649/addons/web/static/src/webclient/actions/action_service.js#L1380-L1381