### PR TITLE
[17.0][FIX] access_roles: serialization errors multiworker

### DIFF
--- a/access_roles/__manifest__.py
+++ b/access_roles/__manifest__.py
@@ -21,7 +21,7 @@
 #############################################################################
 {
     'name': 'Access Roles',
-    'version': '17.0.1.0.0',
+    'version': '17.0.1.0.1',
     'category':'Security',
     'sequence': 1,
     'summary': 'Access Roles for users',

--- a/access_roles/models/__init__.py
+++ b/access_roles/models/__init__.py
@@ -19,12 +19,6 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 #
 #############################################################################
-def run_once(cr, lock_name):
-    """Try to acquire a transaction-scoped advisory lock.
-    Returns True if this worker got the job lock (should run the job)."""
-    cr.execute("SELECT pg_try_advisory_xact_lock(hashtext(%s))", (lock_name,))
-    return cr.fetchone()[0]
-
 from . import access_role
 from . import button_registry
 from . import domain_model
@@ -34,6 +28,7 @@ from . import groupby_registry
 from . import ir_ui_menu
 from . import ir_ui_view
 from . import ir_rule
+from . import registry_rebuild_mixin
 from . import res_users
 from . import res_groups
 from . import role_management

--- a/access_roles/models/__init__.py
+++ b/access_roles/models/__init__.py
@@ -19,6 +19,12 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 #
 #############################################################################
+def run_once(cr, lock_name):
+    """Try to acquire a transaction-scoped advisory lock.
+    Returns True if this worker got the job lock (should run the job)."""
+    cr.execute("SELECT pg_try_advisory_xact_lock(hashtext(%s))", (lock_name,))
+    return cr.fetchone()[0]
+
 from . import access_role
 from . import button_registry
 from . import domain_model

--- a/access_roles/models/button_registry.py
+++ b/access_roles/models/button_registry.py
@@ -22,6 +22,8 @@
 import re
 from odoo import api, Command, fields, models
 
+from . import run_once
+
 
 class ButtonRegistry(models.Model):
     """Class for representing buttons"""
@@ -40,7 +42,8 @@ class ButtonRegistry(models.Model):
         Calls `get_all_buttons` to populate the button registry.
         """
         super()._register_hook()
-        self.get_all_buttons()
+        if run_once(self.env.cr, 'button_registry_rebuild'):
+            self.get_all_buttons()
         return True
 
     def get_all_buttons(self):

--- a/access_roles/models/button_registry.py
+++ b/access_roles/models/button_registry.py
@@ -20,10 +20,7 @@
 #
 #############################################################################
 import re
-from odoo import api, Command, fields, models
-
-from . import run_once
-
+from odoo import Command, fields, models
 
 class ButtonRegistry(models.Model):
     """Class for representing buttons"""
@@ -34,18 +31,6 @@ class ButtonRegistry(models.Model):
     action_name = fields.Char(string='Action/Method Name')
     model_id = fields.Many2one('ir.model', string='Model', ondelete='cascade')
     view_ids = fields.Many2many('ir.ui.view', string='View')
-
-    @api.model
-    def _register_hook(self):
-        """
-        Hook that runs when the module is loaded.
-        Calls `get_all_buttons` to populate the button registry.
-        """
-        super()._register_hook()
-        if run_once(self.env.cr, 'button_registry_rebuild'):
-            self.get_all_buttons()
-            self.env.flush_all()
-        return True
 
     def get_all_buttons(self):
         """Finds buttons from views and stores them."""

--- a/access_roles/models/button_registry.py
+++ b/access_roles/models/button_registry.py
@@ -44,6 +44,7 @@ class ButtonRegistry(models.Model):
         super()._register_hook()
         if run_once(self.env.cr, 'button_registry_rebuild'):
             self.get_all_buttons()
+            self.env.flush_all()
         return True
 
     def get_all_buttons(self):

--- a/access_roles/models/filter_registry.py
+++ b/access_roles/models/filter_registry.py
@@ -22,6 +22,8 @@
 import xml.etree.ElementTree as ET
 from odoo import api, Command, fields, models
 
+from . import run_once
+
 
 class FilterRegistry(models.Model):
     """Stores and manages filters from search views."""
@@ -39,7 +41,8 @@ class FilterRegistry(models.Model):
     def _register_hook(self):
         """Triggers filter extraction during module initialization."""
         super()._register_hook()
-        self.get_all_filters()
+        if run_once(self.env.cr, 'filter_registry_rebuild'):
+            self.get_all_filters()
         return True
 
     def _get_filter_elements_from_arch(self, arch):

--- a/access_roles/models/filter_registry.py
+++ b/access_roles/models/filter_registry.py
@@ -43,6 +43,7 @@ class FilterRegistry(models.Model):
         super()._register_hook()
         if run_once(self.env.cr, 'filter_registry_rebuild'):
             self.get_all_filters()
+            self.env.flush_all()
         return True
 
     def _get_filter_elements_from_arch(self, arch):

--- a/access_roles/models/filter_registry.py
+++ b/access_roles/models/filter_registry.py
@@ -20,10 +20,7 @@
 #
 #############################################################################
 import xml.etree.ElementTree as ET
-from odoo import api, Command, fields, models
-
-from . import run_once
-
+from odoo import Command, fields, models
 
 class FilterRegistry(models.Model):
     """Stores and manages filters from search views."""
@@ -36,15 +33,6 @@ class FilterRegistry(models.Model):
     active = fields.Boolean(default=True)
     model_id = fields.Many2one('ir.model', string='Model', ondelete='cascade')
     view_ids = fields.Many2many('ir.ui.view', string='View')
-
-    @api.model
-    def _register_hook(self):
-        """Triggers filter extraction during module initialization."""
-        super()._register_hook()
-        if run_once(self.env.cr, 'filter_registry_rebuild'):
-            self.get_all_filters()
-            self.env.flush_all()
-        return True
 
     def _get_filter_elements_from_arch(self, arch):
         """Parse the XML arch and return a list of <filter> elements

--- a/access_roles/models/groupby_registry.py
+++ b/access_roles/models/groupby_registry.py
@@ -22,6 +22,8 @@
 import re
 from odoo import api, Command, fields, models
 
+from . import run_once
+
 
 class GroupByRegistry(models.Model):
     """Stores and manages group_by filters from search views."""
@@ -39,7 +41,8 @@ class GroupByRegistry(models.Model):
     def _register_hook(self):
         """Triggers group_by extraction during module initialization."""
         super()._register_hook()
-        self.get_all_groupby()
+        if run_once(self.env.cr, 'groupby_registry_rebuild'):
+            self.get_all_groupby()
         return True
 
     def _extract_groupby_attributes(self, filter_tag):

--- a/access_roles/models/groupby_registry.py
+++ b/access_roles/models/groupby_registry.py
@@ -20,10 +20,7 @@
 #
 #############################################################################
 import re
-from odoo import api, Command, fields, models
-
-from . import run_once
-
+from odoo import Command, fields, models
 
 class GroupByRegistry(models.Model):
     """Stores and manages group_by filters from search views."""
@@ -36,15 +33,6 @@ class GroupByRegistry(models.Model):
     active = fields.Boolean(default=True)
     model_id = fields.Many2one('ir.model', string='Model', ondelete='cascade')
     view_ids = fields.Many2many('ir.ui.view', string='View')
-
-    @api.model
-    def _register_hook(self):
-        """Triggers group_by extraction during module initialization."""
-        super()._register_hook()
-        if run_once(self.env.cr, 'groupby_registry_rebuild'):
-            self.get_all_groupby()
-            self.env.flush_all()
-        return True
 
     def _extract_groupby_attributes(self, filter_tag):
         """Extract attributes from a group_by filter tag."""

--- a/access_roles/models/groupby_registry.py
+++ b/access_roles/models/groupby_registry.py
@@ -43,6 +43,7 @@ class GroupByRegistry(models.Model):
         super()._register_hook()
         if run_once(self.env.cr, 'groupby_registry_rebuild'):
             self.get_all_groupby()
+            self.env.flush_all()
         return True
 
     def _extract_groupby_attributes(self, filter_tag):

--- a/access_roles/models/registry_rebuild_mixin.py
+++ b/access_roles/models/registry_rebuild_mixin.py
@@ -1,0 +1,76 @@
+##############################################################################
+# Copyright (c) 2026 braintec AG (https://braintec.com)
+# All Rights Reserved
+# Licensed under the Odoo Proprietary License v1.0 (OPL).
+# See LICENSE file for full licensing details.
+##############################################################################
+import logging
+import time
+
+from odoo import SUPERUSER_ID, api, models
+
+_logger = logging.getLogger(__name__)
+
+
+def run_once(cr, lock_name):
+    """Try to acquire a transaction-scoped advisory lock."""
+    cr.execute("SELECT pg_try_advisory_xact_lock(hashtext(%s))", (lock_name,))
+    return cr.fetchone()[0]
+
+
+class RegistryRebuildMixin(models.AbstractModel):
+    _name = 'access.roles.registry.rebuild.mixin'
+    _description = 'Access Roles Registry Rebuild Coordinator'
+
+    @api.model
+    def _register_hook(self):
+        super()._register_hook()
+        _logger.info('Scheduling access roles registry rebuild in post-commit hook')
+        self.env.cr.postcommit.add(self._run_all_registry_hooks_postcommit)
+        return True
+
+    def _run_all_registry_hooks_postcommit(self):
+        start = time.monotonic()
+        _logger.info(
+            'Starting access roles registry rebuild after commit (db=%s)',
+            self.env.cr.dbname,
+        )
+        with self.pool.cursor() as new_cr:
+            if not run_once(new_cr, 'access_roles_registry_rebuild_all'):
+                _logger.info(
+                    'Skipping access roles registry rebuild; advisory lock not acquired (db=%s)',
+                    new_cr.dbname,
+                )
+                return False
+
+            try:
+                new_env = api.Environment(
+                    new_cr,
+                    SUPERUSER_ID,
+                    {'access_roles_registry_rebuild_running': True},
+                )
+                _logger.debug('Rebuilding button registry')
+                new_env['button.registry'].get_all_buttons()
+                _logger.debug('Rebuilding filter registry')
+                new_env['filter.registry'].get_all_filters()
+                _logger.debug('Rebuilding groupby registry')
+                new_env['groupby.registry'].get_all_groupby()
+                _logger.debug('Rebuilding tab registry')
+                new_env['tab.registry'].get_all_tabs()
+                _logger.debug('Rebuilding role groups view')
+                new_env['res.groups']._update_role_groups_view()
+                new_env.flush_all()
+                new_cr.commit()
+            except Exception:
+                _logger.exception(
+                    'Access roles registry rebuild failed in post-commit hook (db=%s)',
+                    new_cr.dbname,
+                )
+                raise
+
+        _logger.info(
+            'Finished access roles registry rebuild in %.3fs (db=%s)',
+            time.monotonic() - start,
+            self.env.cr.dbname,
+        )
+        return True

--- a/access_roles/models/res_groups.py
+++ b/access_roles/models/res_groups.py
@@ -25,7 +25,6 @@ from lxml.builder import E
 from odoo import api, models
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
-
 class ResGroups(models.Model):
     """Extends res.groups to dynamically generate role-based group views."""
     _inherit = 'res.groups'
@@ -53,13 +52,6 @@ class ResGroups(models.Model):
     def get_selection_groups(name):
         """Extract group IDs from a selection group field name."""
         return [int(v) for v in name[11:].split('_')]
-
-    @api.model
-    def _register_hook(self):
-        """Hook to update role-based group view after module installation."""
-        super()._register_hook()
-        self._update_role_groups_view()
-        return True
 
     @api.model
     def get_groups_by_application(self):

--- a/access_roles/models/tab_registry.py
+++ b/access_roles/models/tab_registry.py
@@ -20,10 +20,7 @@
 #
 #############################################################################
 import re
-from odoo import api, Command, fields, models
-
-from . import run_once
-
+from odoo import Command, fields, models
 
 class TabRegistry(models.Model):
     """Class for representing tabs"""
@@ -33,15 +30,6 @@ class TabRegistry(models.Model):
     name = fields.Char(string='Tab Name', required=True)
     view_ids = fields.Many2many('ir.ui.view', string='View')
     model_id = fields.Many2one('ir.model', string='Model', ondelete='cascade')
-
-    @api.model
-    def _register_hook(self):
-        """Triggers filter extraction during module initialization."""
-        super()._register_hook()
-        if run_once(self.env.cr, 'tab_registry_rebuild'):
-            self.get_all_tabs()
-            self.env.flush_all()
-        return True
 
     def get_all_tabs(self):
         """Finds buttons from views and stores them."""

--- a/access_roles/models/tab_registry.py
+++ b/access_roles/models/tab_registry.py
@@ -22,6 +22,8 @@
 import re
 from odoo import api, Command, fields, models
 
+from . import run_once
+
 
 class TabRegistry(models.Model):
     """Class for representing tabs"""
@@ -36,7 +38,8 @@ class TabRegistry(models.Model):
     def _register_hook(self):
         """Triggers filter extraction during module initialization."""
         super()._register_hook()
-        self.get_all_tabs()
+        if run_once(self.env.cr, 'tab_registry_rebuild'):
+            self.get_all_tabs()
         return True
 
     def get_all_tabs(self):

--- a/access_roles/models/tab_registry.py
+++ b/access_roles/models/tab_registry.py
@@ -40,6 +40,7 @@ class TabRegistry(models.Model):
         super()._register_hook()
         if run_once(self.env.cr, 'tab_registry_rebuild'):
             self.get_all_tabs()
+            self.env.flush_all()
         return True
 
     def get_all_tabs(self):


### PR DESCRIPTION
This fixes serialization errors when multiple worker are trying to populate the registry tables.
To prevent concurrent updates, we use a pg_try_advisory_xact_lock call to check if another worker is
already processing the data. If the lock is already held, other workers just skip the registry population.