### PR TITLE
Add full translation support to the `crm_dashboard` module and localize all user-facing strings so the dashboard respects the user's language.

### DIFF
--- a/crm_dashboard/__manifest__.py
+++ b/crm_dashboard/__manifest__.py
@@ -21,7 +21,7 @@
 ################################################################################
 {
     'name': "CRM Dashboard",
-    'version': '19.0.1.0.0',
+    'version': '19.0.1.0.1',
     'category': 'Extra Tools',
     'summary': """Get a visual report of CRM through a Dashboard in CRM """,
     'description': """CRM dashboard module brings a multipurpose graphical

--- a/crm_dashboard/i18n/en.po
+++ b/crm_dashboard/i18n/en.po
@@ -1,0 +1,272 @@
+# English translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr ""
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr ""
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr ""
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr ""
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr ""
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr ""
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr ""
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr ""
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr ""
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr ""
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr ""
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr ""
+

--- a/crm_dashboard/i18n/es.po
+++ b/crm_dashboard/i18n/es.po
@@ -1,0 +1,272 @@
+# Spanish (generic) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Ratio Ganado / Perdido"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+

--- a/crm_dashboard/i18n/es_419.po
+++ b/crm_dashboard/i18n/es_419.po
@@ -1,0 +1,272 @@
+# Spanish (Latin America) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: es_419\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Ratio Ganado / Perdido"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+

--- a/crm_dashboard/i18n/es_AR.po
+++ b/crm_dashboard/i18n/es_AR.po
@@ -1,0 +1,272 @@
+# Spanish (Argentina) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: es_AR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Ratio Ganado / Perdido"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+

--- a/crm_dashboard/i18n/es_CL.po
+++ b/crm_dashboard/i18n/es_CL.po
@@ -1,0 +1,272 @@
+# Spanish (Chile) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: es_CL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Ratio Ganado / Perdido"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+

--- a/crm_dashboard/i18n/es_CO.po
+++ b/crm_dashboard/i18n/es_CO.po
@@ -1,0 +1,272 @@
+# Spanish (Colombia) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: es_CO\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Ratio Ganado / Perdido"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+

--- a/crm_dashboard/i18n/es_MX.po
+++ b/crm_dashboard/i18n/es_MX.po
@@ -1,0 +1,272 @@
+# Spanish (Mexico) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: es_MX\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Ratio Ganado / Perdido"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+

--- a/crm_dashboard/i18n/es_PA.po
+++ b/crm_dashboard/i18n/es_PA.po
@@ -1,0 +1,382 @@
+# Spanish (Panama) translations for Odoo Server 19.0.
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the Odoo Server 19.0
+# project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 17:46+0000\n"
+"PO-Revision-Date: 2026-06-28 17:47+0000\n"
+"Last-Translator: \n"
+"Language: es_PA\n"
+"Language-Team: Spanish (Panama)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+msgid "Display Name"
+msgstr ""
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#. odoo-python
+#: code:addons/crm_dashboard/models/crm_lead.py:0
+
+msgid "Expected without Won"
+msgstr "Esperado sin Ganar"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+msgid "ID"
+msgstr ""
+
+#. module: crm_dashboard
+msgid "Lead"
+msgstr ""
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#. odoo-python
+#: code:addons/crm_dashboard/models/crm_lead.py:0
+
+msgid "Lost"
+msgstr "Perdido"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+msgid "Sales Order"
+msgstr ""
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+msgid "Sales Team"
+msgstr ""
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+msgid "Total Ratio"
+msgstr ""
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+
+#. module: crm_dashboard
+msgid "UTM Campaign"
+msgstr ""
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+msgid "User"
+msgstr ""
+
+#. module: crm_dashboard
+#. odoo-javascript
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:0
+
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#. odoo-python
+#: code:addons/crm_dashboard/models/crm_lead.py:0
+
+msgid "Won"
+msgstr "Ganado"
+

--- a/crm_dashboard/i18n/es_PE.po
+++ b/crm_dashboard/i18n/es_PE.po
@@ -1,0 +1,272 @@
+# Spanish (Peru) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: es_PE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Ratio Ganado / Perdido"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+

--- a/crm_dashboard/i18n/es_VE.po
+++ b/crm_dashboard/i18n/es_VE.po
@@ -1,0 +1,272 @@
+# Spanish (Venezuela) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: es_VE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para los leads asociados a este equipo de ventas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Tablero"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Objetivo"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "El valor objetivo para el vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Ratio Ganado / Perdido"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Ratio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Año"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Tablero CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Mis Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Mis Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Ingresos Esperados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Ratio de Éxito"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tiempo Promedio de Cierre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Ratio Ganado/Perdido de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Sin Asignar"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Actividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campaña"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Medio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origen"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Ingresos Totales por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Actividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Actividades Recientes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Mejores Vendedores por Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Ingresos por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Cantidad por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Cantidad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Actividad:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nombre:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumen:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Actividad"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Ingresos Gastados"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Ingresos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Sin Asignar"
+

--- a/crm_dashboard/i18n/pt.po
+++ b/crm_dashboard/i18n/pt.po
@@ -1,0 +1,272 @@
+# Portuguese (generic) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para os leads associados a esta equipa de vendas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Painel CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Painel"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Meta"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "O valor da meta para o vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Rácio Ganho / Perda"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Rácio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Ano"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mês"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Painel CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Meus Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Minhas Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Receita Esperada"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Rácio de Ganho"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tempo Médio de Fecho"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Rácio Ganho/Perda de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Não Atribuídos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mês"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Atividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campanha"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Meio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origem"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Receita Total por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Atividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Atividades Recentes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Melhores Vendedores por Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Receita por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Quantidade por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Quantidade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Atividade:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nome:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumo:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Atividade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Receita de Despesas"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Não Atribuídos"
+

--- a/crm_dashboard/i18n/pt_BR.po
+++ b/crm_dashboard/i18n/pt_BR.po
@@ -1,0 +1,272 @@
+# Portuguese (Brazil) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para os leads associados a esta equipa de vendas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Painel CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Painel"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Meta"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "O valor da meta para o vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Rácio Ganho / Perda"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Rácio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Ano"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mês"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Painel CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Meus Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Minhas Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Receita Esperada"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Rácio de Ganho"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tempo Médio de Fecho"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Rácio Ganho/Perda de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Não Atribuídos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mês"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Atividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campanha"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Meio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origem"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Receita Total por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Atividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Atividades Recentes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Melhores Vendedores por Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Receita por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Quantidade por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Quantidade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Atividade:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nome:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumo:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Atividade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Receita de Despesas"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Não Atribuídos"
+

--- a/crm_dashboard/i18n/pt_PT.po
+++ b/crm_dashboard/i18n/pt_PT.po
@@ -1,0 +1,272 @@
+# Portuguese (Portugal) translations for crm_dashboard module.
+# Copyright (C) 2026 OPENTECH SOLUTIONS by ROSERO ONE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0).
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-28 00:55+0000\n"
+"PO-Revision-Date: 2026-06-28 00:55+0000\n"
+"Last-Translator: \n"
+"Language: pt_PT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_dashboard
+#: model:ir.actions.client,name:crm_dashboard.action_crm_lead_all_dashboard
+msgid "CRM"
+msgstr "CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead"
+msgstr "Lead de CRM"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_crm_team__crm_lead_state_id
+msgid "CRM Lead stage for leads associated with this sales team."
+msgstr "Etapa de leads de CRM para os leads associados a esta equipa de vendas."
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.view_users_form
+msgid "CRM dashboard"
+msgstr "Painel CRM"
+
+#. module: crm_dashboard
+#: model:ir.ui.menu,name:crm_dashboard.crm_dashboard_menu
+msgid "Dashboard"
+msgstr "Painel"
+
+#. module: crm_dashboard
+#: model_terms:ir.ui.view,arch_db:crm_dashboard.utm_campaign_view_form
+msgid "Ratio"
+msgstr "Ratio"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,field_description:crm_dashboard.field_res_users__sales
+msgid "Target"
+msgstr "Meta"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_res_users__sales
+msgid "The target value for the salesperson."
+msgstr "O valor da meta para o vendedor."
+
+#. module: crm_dashboard
+#: model:ir.actions.act_window,name:crm_dashboard.utm_campaign_view_form_ratio_action
+#: code:addons/crm_dashboard/models/utm_campaign.py:0
+msgid "Win Loss Ratio"
+msgstr "Rácio Ganho / Perda"
+
+#. module: crm_dashboard
+#: model:ir.model.fields,help:crm_dashboard.field_utm_campaign__total_ratio
+msgid "Total lead ratio"
+msgstr "Rácio total de leads"
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:20
+msgid "This Year"
+msgstr "Este Ano"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:25
+msgid "This Quarter"
+msgstr "Este Trimestre"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:30
+msgid "This Month"
+msgstr "Este Mês"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:33
+msgid "This Week"
+msgstr "Esta Semana"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:10
+msgid "CRM Dashboard"
+msgstr "Painel CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:56
+msgid "My Leads"
+msgstr "Meus Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:72
+msgid "My Opportunities"
+msgstr "Minhas Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:88
+msgid "Expected Revenue"
+msgstr "Receita Esperada"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:105
+msgid "Revenue"
+msgstr "Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:121
+msgid "Win Ratio"
+msgstr "Rácio de Ganho"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:138
+msgid "Average Closing Time"
+msgstr "Tempo Médio de Fecho"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:154
+msgid "Opportunity Win Loss Ratio"
+msgstr "Rácio Ganho/Perda de Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:171
+msgid "Unassigned Leads Count"
+msgstr "Leads Não Atribuídos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:181
+msgid "Leads Stage"
+msgstr "Etapa de Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:195
+msgid "Leads By Months"
+msgstr "Leads por Mês"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:210
+msgid "CRM Activities"
+msgstr "Atividades CRM"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:225
+msgid "Leads Group By Campaign"
+msgstr "Leads Agrupados por Campanha"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:240
+msgid "Leads Group By Medium"
+msgstr "Leads Agrupados por Meio"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:255
+msgid "Leads Group By Source"
+msgstr "Leads Agrupados por Origem"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:270
+msgid "Lost Opportunity/Lead"
+msgstr "Oportunidades/Leads Perdidos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:285
+msgid "Total Revenue by Salesperson"
+msgstr "Receita Total por Vendedor"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:299
+msgid "Upcoming Activities"
+msgstr "Próximas Atividades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:351
+msgid "Recent Activities"
+msgstr "Atividades Recentes"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:407
+msgid "Top Salesperson Revenue"
+msgstr "Melhores Vendedores por Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:438
+msgid "Top Country Wise Revenue"
+msgstr "Top Receita por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:469
+msgid "Top Country Wise Count"
+msgstr "Top Quantidade por País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:413
+msgid "Opportunity"
+msgstr "Oportunidade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:444
+msgid "Country"
+msgstr "País"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:476
+msgid "Count"
+msgstr "Quantidade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:135
+msgid "Seconds"
+msgstr "Segundos"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:320
+msgid "Activity:"
+msgstr "Atividade:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:327
+msgid "Name:"
+msgstr "Nome:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:333
+msgid "Summary:"
+msgstr "Resumo:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/xml/dashboard_templates.xml:388
+msgid "Sales Rep:"
+msgstr "Vendedor:"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:207
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:297
+msgid "Activity"
+msgstr "Atividade"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:181
+msgid "Leads"
+msgstr "Leads"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:193
+msgid "Opportunities"
+msgstr "Oportunidades"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:205
+msgid "Expense Revenue"
+msgstr "Receita de Despesas"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:217
+msgid "Revenue"
+msgstr "Receita"
+
+#. module: crm_dashboard
+#: code:addons/crm_dashboard/static/src/js/crm_dashboard.js:229
+msgid "Unassigned Leads"
+msgstr "Leads Não Atribuídos"
+

--- a/crm_dashboard/models/crm_lead.py
+++ b/crm_dashboard/models/crm_lead.py
@@ -19,10 +19,19 @@
 #    If not, see <http://www.gnu.org/licenses/>.
 #
 ################################################################################
-import calendar
+import babel.dates
 from dateutil.relativedelta import relativedelta
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.tools.safe_eval import datetime
+
+
+def _month_label(month_number, lang):
+    """Return the localized month name (e.g. 'June' / 'Junio') for the
+    given month number (1-12) and the user's language."""
+    from datetime import date as _date
+    return babel.dates.format_date(
+        _date(2000, month_number, 1), format='MMMM', locale=lang or 'en_US',
+    )
 
 
 def get_period_start_date(period):
@@ -141,7 +150,8 @@ class CRMLead(models.Model):
             if month not in month_value:
                 month_value.append(month)
             month_count.append(month)
-        month_val = [{'label': calendar.month_name[month],
+        lang = self.env.lang or 'en_US'
+        month_val = [{'label': _month_label(month, lang),
                       'value': month_count.count(month)} for month in
                      month_value]
         names = [record['label'] for record in month_val]
@@ -154,18 +164,27 @@ class CRMLead(models.Model):
         """Sales Activity Pie"""
         start_date = get_period_start_date(period)
         self._cr.execute('''
-               SELECT mail_activity_type.name, COUNT(*) 
-               FROM mail_activity 
-               INNER JOIN mail_activity_type 
+               SELECT mail_activity_type.name, COUNT(*)
+               FROM mail_activity
+               INNER JOIN mail_activity_type
                    ON mail_activity.activity_type_id = mail_activity_type.id
-               INNER JOIN crm_lead 
-                   ON mail_activity.res_id = crm_lead.id 
+               INNER JOIN crm_lead
+                   ON mail_activity.res_id = crm_lead.id
                    AND mail_activity.res_model = 'crm.lead'
                WHERE crm_lead.create_date >= %s
                GROUP BY mail_activity_type.name
            ''', (start_date,))
         data = self._cr.dictfetchall()
-        names = [record['name']['en_US'] for record in data]
+        # mail_activity_type.name is a translate=True JSONB field. The original
+        # code forced 'en_US' which ignored the user's language. Use the user's
+        # lang instead, falling back to en_US if the language isn't installed.
+        user_lang = self.env.lang or 'en_US'
+        names = [
+            (record['name'].get(user_lang)
+             or record['name'].get('en_US')
+             or next(iter(record['name'].values()), ''))
+            for record in data
+        ]
         counts = [record['count'] for record in data]
         return [counts, names]
 
@@ -217,9 +236,7 @@ class CRMLead(models.Model):
     @api.model
     def get_total_lost_crm(self, period):
         """Lost Opportunity or Lead Graph"""
-        month_dict = {}
-
-        # Format the start date to be used in the SQL query
+        # Initialize the dictionary with month names and counts (localized)
         start_date = get_period_start_date(period)
 
         if period == 'year':
@@ -229,35 +246,42 @@ class CRMLead(models.Model):
         else:
             num_months = 1
 
-            # Initialize the dictionary with month names and counts
+        lang = self.env.lang or 'en_US'
+        month_dict = {}
         for i in range(num_months):
             current_month = start_date + relativedelta(months=i)
-            month_name = current_month.strftime('%B')
-            month_dict[month_name] = 0
+            # Group by month number (locale-independent) so the SQL doesn't
+            # return month names in the cluster's default locale.
+            month_num = current_month.month
+            month_name = _month_label(month_num, lang)
+            month_dict[month_num] = {'label': month_name, 'count': 0}
 
-            # Execute the SQL query to count lost opportunities
-        self._cr.execute('''SELECT TO_CHAR(create_date, 'Month') AS month, 
-                                       COUNT(id) 
+        # Execute the SQL query: group by month NUMBER (not name) so the
+        # result is independent of the cluster locale.
+        self._cr.execute('''SELECT EXTRACT(MONTH FROM create_date)::int AS month_num,
+                                       COUNT(id) AS count
                                 FROM crm_lead
-                                WHERE probability = 0 
-                                  AND active = FALSE 
+                                WHERE probability = 0
+                                  AND active = FALSE
                                   AND create_date >= %s
-                                GROUP BY TO_CHAR(create_date, 'Month')
-                                ORDER BY TO_CHAR(create_date, 'Month')''',
+                                GROUP BY month_num
+                                ORDER BY month_num''',
                          (start_date,))
 
         data = self._cr.dictfetchall()
 
         # Update month_dict with the results from the query
         for rec in data:
-            month_name = rec[
-                'month'].strip()  # Strip the month name to remove extra spaces
-            if month_name in month_dict:
-                month_dict[month_name] = rec['count']
+            month_num = rec['month_num']
+            if month_num in month_dict:
+                month_dict[month_num]['count'] = rec['count']
 
+        # Preserve original response shape: ordered list of month labels and
+        # parallel list of counts.
+        ordered = sorted(month_dict.items(), key=lambda kv: kv[0])
         result = {
-            'month': list(month_dict.keys()),
-            'count': list(month_dict.values())
+            'month': [entry['label'] for _, entry in ordered],
+            'count': [entry['count'] for _, entry in ordered],
         }
 
         return result
@@ -325,9 +349,14 @@ class CRMLead(models.Model):
         # Calculate expected revenue without won
         exp_revenue_without_won = revenues[0] - revenues[1]
 
-        # Prepare the data for the pie chart
+        # Prepare the data for the pie chart. Labels are translated via _()
+        # so they follow the current user's language.
         revenue_pie_count = [exp_revenue_without_won, revenues[1], revenues[2]]
-        revenue_pie_title = ['Expected without Won', 'Won', 'Lost']
+        revenue_pie_title = [
+            _('Expected without Won'),
+            _('Won'),
+            _('Lost'),
+        ]
 
         return [revenue_pie_count, revenue_pie_title]
 

--- a/crm_dashboard/static/src/js/crm_dashboard.js
+++ b/crm_dashboard/static/src/js/crm_dashboard.js
@@ -3,6 +3,8 @@ import {registry} from "@web/core/registry";
 import {Component} from "@odoo/owl";
 import {onWillStart, onMounted, useState, useRef, useEffect} from "@odoo/owl";
 import {useService} from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { sprintf } from "@odoo/owl";
 
 export class CrmDashboard extends Component {
     setup() {
@@ -34,7 +36,45 @@ export class CrmDashboard extends Component {
             country_count: [],
             country_revenue: [],
             recent_activities:[],
-
+            // Pre-translated UI strings (used by dashboard_templates.xml).
+            // We translate here in JS (_t) because the QWeb template does
+            // not have _t in its context. Keys are camelCase.
+            texts: {
+                thisYear: _t('This Year'),
+                thisQuarter: _t('This Quarter'),
+                thisMonth: _t('This Month'),
+                thisWeek: _t('This Week'),
+                crmDashboard: _t('CRM Dashboard'),
+                myLeads: _t('My Leads'),
+                myOpportunities: _t('My Opportunities'),
+                expectedRevenue: _t('Expected Revenue'),
+                revenue: _t('Revenue'),
+                winRatio: _t('Win Ratio'),
+                averageClosingTime: _t('Average Closing Time'),
+                opportunityWinLossRatio: _t('Opportunity Win Loss Ratio'),
+                unassignedLeadsCount: _t('Unassigned Leads Count'),
+                leadsStage: _t('Leads Stage'),
+                leadsByMonths: _t('Leads By Months'),
+                crmActivities: _t('CRM Activities'),
+                leadsGroupByCampaign: _t('Leads Group By Campaign'),
+                leadsGroupByMedium: _t('Leads Group By Medium'),
+                leadsGroupBySource: _t('Leads Group By Source'),
+                lostOpportunityLead: _t('Lost Opportunity/Lead'),
+                totalRevenueBySalesperson: _t('Total Revenue by Salesperson'),
+                upcomingActivities: _t('Upcoming Activities'),
+                recentActivities: _t('Recent Activities'),
+                topSalespersonRevenue: _t('Top Salesperson Revenue'),
+                topCountryWiseRevenue: _t('Top Country Wise Revenue'),
+                topCountryWiseCount: _t('Top Country Wise Count'),
+                opportunity: _t('Opportunity'),
+                country: _t('Country'),
+                count: _t('Count'),
+                seconds: _t('Seconds'),
+                activityLabel: _t('Activity:'),
+                nameLabel: _t('Name:'),
+                summaryLabel: _t('Summary:'),
+                salesRepLabel: _t('Sales Rep:'),
+            },
         })
         onWillStart(async () => {
             await this.fetch_data();
@@ -138,7 +178,7 @@ export class CrmDashboard extends Component {
         var date = this.SetPeriods()
         this.action.doAction({
             type: "ir.actions.act_window",
-            name: "Leads",
+            name: _t('Leads'),
             res_model: 'crm.lead',
             views: [[false, "kanban"], [false, "form"]],
             target: "current",
@@ -150,7 +190,7 @@ export class CrmDashboard extends Component {
         var date = this.SetPeriods()
         this.action.doAction({
             type: "ir.actions.act_window",
-            name: "Opportunities",
+            name: _t('Opportunities'),
             res_model: 'crm.lead',
             views: [[false, "kanban"], [false, "form"]],
             target: "current",
@@ -162,7 +202,7 @@ export class CrmDashboard extends Component {
         var date = this.SetPeriods()
         this.action.doAction({
             type: "ir.actions.act_window",
-            name: "Expense Revenue",
+            name: _t('Expense Revenue'),
             res_model: 'crm.lead',
             views: [[false, "list"], [false, "form"]],
             target: "current",
@@ -174,7 +214,7 @@ export class CrmDashboard extends Component {
         var date = this.SetPeriods()
         this.action.doAction({
             type: "ir.actions.act_window",
-            name: "Revenue",
+            name: _t('Revenue'),
             res_model: 'crm.lead',
             views: [[false, "list"], [false, "form"]],
             target: "current",
@@ -186,7 +226,7 @@ export class CrmDashboard extends Component {
         var date = this.SetPeriods()
         this.action.doAction({
             type: "ir.actions.act_window",
-            name: "Unassigned Leads",
+            name: _t('Unassigned Leads'),
             res_model: 'crm.lead',
             views: [[false, "list"], [false, "form"]],
             target: "current",
@@ -202,7 +242,7 @@ export class CrmDashboard extends Component {
         const data = {
             labels: arrays[1],
             datasets: [{
-                label: 'Leads',
+                label: _t('Leads'),
                 data: arrays[0],
                 backgroundColor: [
                     "#003f5c",
@@ -247,7 +287,7 @@ export class CrmDashboard extends Component {
         const data = {
             labels: arrays[1],
             datasets: [{
-                label: 'Leads',
+                label: _t('Leads'),
                 data: arrays[0],
                 backgroundColor: [
                     "#003f5c",
@@ -292,7 +332,7 @@ export class CrmDashboard extends Component {
         const data = {
             labels: arrays[1],
             datasets: [{
-                label: 'Activity',
+                label: _t('Activity'),
                 data: arrays[0],
                 backgroundColor: [
                     "#003f5c",
@@ -337,7 +377,7 @@ export class CrmDashboard extends Component {
         const data = {
             labels: arrays[1],
             datasets: [{
-                label: 'Activity',
+                label: _t('Activity'),
                 data: arrays[0],
                 backgroundColor: [
                     "#003f5c",
@@ -382,7 +422,7 @@ export class CrmDashboard extends Component {
         const data = {
             labels: arrays[1],
             datasets: [{
-                label: 'Activity',
+                label: _t('Activity'),
                 data: arrays[0],
                 backgroundColor: [
                     "#003f5c",
@@ -427,7 +467,7 @@ export class CrmDashboard extends Component {
         const data = {
             labels: arrays[1],
             datasets: [{
-                label: 'Activity',
+                label: _t('Activity'),
                 data: arrays[0],
                 backgroundColor: [
                     "#003f5c",
@@ -472,7 +512,7 @@ export class CrmDashboard extends Component {
         const data = {
             labels: arrays['month'],
             datasets: [{
-                label: 'Activity',
+                label: _t('Activity'),
                 data: arrays['count'],
                 backgroundColor: [
                     "#003f5c",
@@ -517,7 +557,7 @@ export class CrmDashboard extends Component {
         const data = {
             labels: arrays[1],
             datasets: [{
-                label: 'Activity',
+                label: _t('Activity'),
                 data: arrays[0],
                 backgroundColor: [
                     "#003f5c",

--- a/crm_dashboard/static/src/xml/dashboard_templates.xml
+++ b/crm_dashboard/static/src/xml/dashboard_templates.xml
@@ -7,8 +7,7 @@
                     <div class="col-sm-12 mb-4">
                         <div class="row">
                             <div class="col-12 col-sm-12 col-md-8">
-                                <h2 class="section-header">CRM Dashboard
-                                </h2>
+                                <h2 class="section-header"><t t-esc="state.texts.crmDashboard"/></h2>
                             </div>
                             <div class="col-12 col-sm-12 col-md-4">
                                 <form class="form-group">
@@ -17,19 +16,13 @@
                                             t-on-change="OnChangePeriods"
                                             class="form-control">
                                         <option id="this_year"
-                                                value="year">This Year
-                                        </option>
+                                                value="year"><t t-out="state.texts.thisYear"/></option>
                                         <option id="this_quarter"
-                                                value="quarter">This
-                                            Quarter
-                                        </option>
+                                                value="quarter"><t t-out="state.texts.thisQuarter"/></option>
                                         <option id="this_month"
-                                                value="month"
-                                                selected="">This Month
-                                        </option>
+                                                value="month" selected=""><t t-out="state.texts.thisMonth"/></option>
                                         <option id="this_week"
-                                                value="week">This Week
-                                        </option>
+                                                value="week"><t t-out="state.texts.thisWeek"/></option>
                                     </select>
                                 </form>
                             </div>
@@ -53,7 +46,7 @@
                                         <t t-esc="this.state.leads"/>
                                     </span>
                                 </h3>
-                                <h4>My Leads</h4>
+                                <h4><t t-esc="state.texts.myLeads"/></h4>
                             </div>
                         </div>
                     </div>
@@ -69,7 +62,7 @@
                                         <t t-esc="this.state.opportunities"/>
                                     </span>
                                 </h3>
-                                <h4>My Opportunities</h4>
+                                <h4><t t-esc="state.texts.myOpportunities"/></h4>
                             </div>
                         </div>
                     </div>
@@ -85,7 +78,7 @@
                                         <t t-esc="this.state.exp_revenue"/>
                                     </span>
                                 </h3>
-                                <h4>Expected Revenue</h4>
+                                <h4><t t-esc="state.texts.expectedRevenue"/></h4>
                             </div>
                         </div>
                     </div>
@@ -102,7 +95,7 @@
                                         <t t-esc="this.state.revenue"/>
                                     </span>
                                 </h3>
-                                <h4>Revenue</h4>
+                                <h4><t t-esc="state.texts.revenue"/></h4>
                             </div>
                         </div>
                     </div>
@@ -118,7 +111,7 @@
                                         <t t-esc="this.state.win_ratio"/>
                                     </span>
                                 </h3>
-                                <h4>Win Ratio</h4>
+                                <h4><t t-esc="state.texts.winRatio"/></h4>
                             </div>
                         </div>
                     </div>
@@ -132,10 +125,10 @@
                                 <h3>
                                     <span>
                                         <t t-esc="this.state.avg_close_time"/>
-                                        Seconds
+                                        <t t-out="' ' + state.texts.seconds"/>
                                     </span>
                                 </h3>
-                                <h4>Average Closing Time</h4>
+                                <h4><t t-esc="state.texts.averageClosingTime"/></h4>
                             </div>
                         </div>
                     </div>
@@ -151,7 +144,7 @@
                                         <t t-esc="this.state.opportunity_ratio"/>
                                     </span>
                                 </h3>
-                                <h4>Opportunity Win Loss Ratio</h4>
+                                <h4><t t-esc="state.texts.opportunityWinLossRatio"/></h4>
                             </div>
                         </div>
                     </div>
@@ -168,7 +161,7 @@
                                         <t t-esc="this.state.unassigned_leads"/>
                                     </span>
                                 </h3>
-                                <h4>Unassigned Leads Count</h4>
+                                <h4><t t-esc="state.texts.unassignedLeadsCount"/></h4>
                             </div>
                         </div>
                     </div>
@@ -178,7 +171,7 @@
                         <div class="row" style="display:flex; padding: 20px;">
                             <div class="card-body" id="in_ex_body_hide">
                                 <div class="leads_stages chart-container card-shadow">
-                                    <h2>Leads Stage</h2>
+                                    <h2><t t-esc="state.texts.leadsStage"/></h2>
                                     <hr/>
                                     <div class="graph_canvas">
                                         <canvas t-ref="leads_stage" width="200"
@@ -192,7 +185,7 @@
                         <div class="row" style="display:flex; padding: 20px;">
                             <div class="card-body" id="in_ex_body_hide">
                                 <div class="leads_stages chart-container card-shadow">
-                                    <h2>Leads By Months</h2>
+                                    <h2><t t-esc="state.texts.leadsByMonths"/></h2>
                                     <hr/>
                                     <div class="graph_canvas">
                                         <canvas t-ref="leads_by_month"
@@ -207,7 +200,7 @@
                         <div class="row" style="display:flex; padding: 20px;">
                             <div class="card-body" id="in_ex_body_hide">
                                 <div class="leads_stages chart-container card-shadow">
-                                    <h2>CRM Activities</h2>
+                                    <h2><t t-esc="state.texts.crmActivities"/></h2>
                                     <hr/>
                                     <div class="graph_canvas">
                                         <canvas t-ref="crm_activities"
@@ -222,7 +215,7 @@
                         <div class="row" style="display:flex; padding: 20px;">
                             <div class="card-body" id="in_ex_body_hide">
                                 <div class="leads_campaign chart-container card-shadow">
-                                    <h2>Leads Group By Campaign</h2>
+                                    <h2><t t-esc="state.texts.leadsGroupByCampaign"/></h2>
                                     <hr/>
                                     <div class="graph_canvas">
                                         <canvas t-ref="leads_campaign"
@@ -237,7 +230,7 @@
                         <div class="row" style="display:flex; padding: 20px;">
                             <div class="card-body" id="in_ex_body_hide">
                                 <div class="leads_medium chart-container card-shadow">
-                                    <h2>Leads Group By Medium</h2>
+                                    <h2><t t-esc="state.texts.leadsGroupByMedium"/></h2>
                                     <hr/>
                                     <div class="graph_canvas">
                                         <canvas t-ref="leads_medium"
@@ -252,7 +245,7 @@
                         <div class="row" style="display:flex; padding: 20px;">
                             <div class="card-body" id="in_ex_body_hide">
                                 <div class="leads_source chart-container card-shadow">
-                                    <h2>Leads Group By Source</h2>
+                                    <h2><t t-esc="state.texts.leadsGroupBySource"/></h2>
                                     <hr/>
                                     <div class="graph_canvas">
                                         <canvas t-ref="leads_source"
@@ -267,7 +260,7 @@
                         <div class="row" style="display:flex; padding: 20px;">
                             <div class="card-body" id="in_ex_body_hide">
                                 <div class="leads_lost chart-container card-shadow">
-                                    <h2>Lost Opportunity/Lead</h2>
+                                    <h2><t t-esc="state.texts.lostOpportunityLead"/></h2>
                                     <hr/>
                                     <div class="graph_canvas">
                                         <canvas t-ref="leads_lost"
@@ -282,7 +275,7 @@
                         <div class="row" style="display:flex; padding: 20px;">
                             <div class="card-body" id="in_ex_body_hide">
                                 <div class="total_revenue chart-container card-shadow">
-                                    <h2>Total Revenue by Salesperson</h2>
+                                    <h2><t t-esc="state.texts.totalRevenueBySalesperson"/></h2>
                                     <hr/>
                                     <div class="graph_canvas">
                                         <canvas t-ref="total_revenue"
@@ -296,7 +289,7 @@
 
                     <div class="upcoming_activities_div col-12 col-sm-12 col-md-4">
                         <div class="chart-container card-shadow">
-                            <h3 class="h5">Upcoming Activities</h3>
+                            <h3 class="h5"><t t-esc="state.texts.upcomingActivities"/></h3>
                             <hr/>
                             <div class="crm_scroll_table"
                                  style="max-height:530px;">
@@ -317,20 +310,17 @@
                                                                     <t t-set="lang_cu"
                                                                        t-value="state.current_lang"/>
                                                                     <t t-if="lang_cu in activity[4]">
-                                                                        Activity:
-                                                                        <span style="font-size: 16px;color: #4c4c4c;">
+                                                                        <t t-out="state.texts.activityLabel"/> <span style="font-size: 16px;color: #4c4c4c;">
                                                                             <t t-esc="activity[4][lang_cu]"/>
                                                                         </span>
                                                                     </t>
                                                                 </li>
-                                                                <li>
-                                                                    Name:
+                                                                <li><t t-out="state.texts.nameLabel"/>
                                                                     <span style="font-size: 15px;color: #4c4c4c;">
                                                                         <t t-esc="activity[3]"/>
                                                                     </span>
                                                                 </li>
-                                                                <li t-if="activity[2]">
-                                                                    Summary:
+                                                                <li t-if="activity[2]"><t t-out="state.texts.summaryLabel"/>
                                                                     <span style="font-size: 13px;color: #4c4c4c;">
                                                                         <t t-esc="activity[2]"/>
                                                                     </span>
@@ -348,7 +338,7 @@
                     </div>
                     <div class="recent_activity_div col-12 col-sm-12 col-md-4">
                         <div class="chart-container card-shadow">
-                            <h3 class="h5">Recent Activities</h3>
+                            <h3 class="h5"><t t-esc="state.texts.recentActivities"/></h3>
                             <hr/>
                             <div class="crm_scroll_table">
                                 <div class="items-table">
@@ -367,26 +357,23 @@
                                                                     <t t-set="lang_cu"
                                                                        t-value="state.current_lang"/>
                                                                     <t t-if="lang_cu in activity[4]">
-                                                                        Activity:
-                                                                        <span style="font-size: 15px;color: #4c4c4c;">
+                                                                        <t t-out="state.texts.activityLabel"/> <span style="font-size: 15px;color: #4c4c4c;">
                                                                             <t t-esc="activity[4][lang_cu]"/>
                                                                         </span>
                                                                     </t>
                                                                 </li>
-                                                                <li>Name:
+                                                                <li><t t-out="state.texts.nameLabel"/>
                                                                     <span style="font-size: 13px;color: #4c4c4c;">
                                                                         <t t-esc="activity[3]"/>
                                                                     </span>
                                                                 </li>
-                                                                <li t-if="activity[2]">
-                                                                    Summary:
+                                                                <li t-if="activity[2]"><t t-out="state.texts.summaryLabel"/>
                                                                     <span style="font-size: 13px;color: #4c4c4c;">
                                                                         <t t-esc="activity[2]"/>
                                                                     </span>
                                                                 </li>
-                                                                <li>
-                                                                    Sales Rep:
-                                                                    <t
+                                                                <li><t t-out="state.texts.salesRepLabel"/>
+                                            <t
                                                                             t-esc="activity[5]"/>
                                                                 </li>
                                                             </ul>
@@ -404,14 +391,14 @@
                     <div class="row mt-5">
                         <div class="top_sp_revenue_div col-12 col-sm-12 col-md-4">
                             <div class="chart-container card-shadow">
-                                <h3 class="h5">Top Salesperson Revenue</h3>
+                                <h3 class="h5"><t t-esc="state.texts.topSalespersonRevenue"/></h3>
                                 <hr/>
                                 <table class="table table-hover"
                                        id="salesperson_revenue_table">
                                     <thead>
                                         <tr>
-                                            <th>Opportunity</th>
-                                            <th>Revenue</th>
+                                            <th><t t-esc="state.texts.opportunity"/></th>
+                                            <th><t t-esc="state.texts.revenue"/></th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -435,14 +422,14 @@
                         </div>
                         <div class="top_country_revenue_div col-12 col-sm-12 col-md-4">
                             <div class="chart-container card-shadow">
-                                <h3 class="h5">Top Country Wise Revenue</h3>
+                                <h3 class="h5"><t t-esc="state.texts.topCountryWiseRevenue"/></h3>
                                 <hr/>
                                 <table class="table table-hover"
                                        id="country_revenue_table">
                                     <thead>
                                         <tr>
-                                            <th>Country</th>
-                                            <th>Revenue</th>
+                                            <th><t t-esc="state.texts.country"/></th>
+                                            <th><t t-esc="state.texts.revenue"/></th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -466,14 +453,14 @@
                         </div>
                         <div class="top_country_count_div col-12 col-sm-12 col-md-4">
                             <div class="chart-container card-shadow">
-                                <h3 class="h5">Top Country Wise Count</h3>
+                                <h3 class="h5"><t t-esc="state.texts.topCountryWiseCount"/></h3>
                                 <hr/>
                                 <table class="table table-hover"
                                        id="country_count_table">
                                     <thead>
                                         <tr>
-                                            <th>Country</th>
-                                            <th>Count</th>
+                                            <th><t t-esc="state.texts.country"/></th>
+                                            <th><t t-esc="state.texts.count"/></th>
                                         </tr>
                                     </thead>
                                     <tbody>


### PR DESCRIPTION
## Changes

### Model (`models/crm_lead.py`)
- Render month names via `babel.dates` using the user's language instead of hardcoded English (`calendar.month_name`) or DB-locale-dependent `TO_CHAR`.
- Read `mail_activity_type.name` (a `translate=True` JSONB field) from the user's lang with fallback to `en_US`, instead of forcing `en_US`.
- Wrap revenue pie labels (`Expected without Won`, `Won`, `Lost`) with `_()` for translation.
- Group the lost-leads query by **month number** (locale-independent) and label months on the Python side to keep ordering stable across database locales.

### JavaScript (`static/src/js/crm_dashboard.js`)
- Import `_t` from `@web/core/l10n/translation`.
- Pre-translate all visible UI strings (titles, period labels, chart legends, action window names) into a `state.texts` map so they can be consumed from the QWeb template, which has no `_t` in its context.
- Wrap `action.doAction` `name` and Chart.js `label` strings with `_t()`.

### QWeb template (`static/src/xml/dashboard_templates.xml`)
- Replace all hardcoded English text with `state.texts.*` lookups so the rendered UI follows the current user's language.

### Manifest
- Bump version `19.0.1.0.0` → `19.0.1.0.1`.

### i18n
- Add initial `.po` files for: `en`, `es`, `es_419`, `es_AR`, `es_CL`, `es_CO`, `es_MX`, `es_PA`, `es_PE`, `es_VE`, `pt`, `pt_BR`, `pt_PT`.