### PR TITLE
[FIX] invoice_bill_for_selected_order_lines: fix selected line billing

### DIFF
--- a/invoice_bill_for_selected_order_lines/__manifest__.py
+++ b/invoice_bill_for_selected_order_lines/__manifest__.py
@@ -21,7 +21,7 @@
 ###############################################################################
 {
     'name': "Invoice Or Bill For Selected Order Lines",
-    'version': '15.0.1.0.0',
+    'version': '15.0.1.0.1',
     'category': 'Accounting,Purchases,Sales',
     'summary': 'Can use only selected products to invoice as well as bills.',
     'description': 'We can create invoice for the selected products from order'

--- a/invoice_bill_for_selected_order_lines/models/purchase_order.py
+++ b/invoice_bill_for_selected_order_lines/models/purchase_order.py
@@ -53,30 +53,34 @@ class PurchaseOrder(models.Model):
             pending_section = None
             # Invoice values.
             invoice_vals = order._prepare_invoice()
+            selected_lines = order.order_line.filtered(
+                lambda line: line.is_product_select
+                and not line.display_type
+                and not float_is_zero(
+                    line.qty_to_invoice, precision_digits=precision))
+            lines_to_invoice = selected_lines or order.order_line
             # Invoice line values (keep only necessary sections).
             for line in order.order_line:
-                if ((line.is_product_select is True) or True not in
-                        order.order_line.mapped('is_product_select')):
-                    if line.display_type == 'line_section':
-                        pending_section = line
-                        continue
-                    if not float_is_zero(line.qty_to_invoice,
-                                         precision_digits=precision):
-                        if pending_section:
-                            line_vals = (
-                                pending_section._prepare_account_move_line())
-                            line_vals.update({'sequence': sequence})
-                            invoice_vals['invoice_line_ids'].append(
-                                (0, 0, line_vals))
-                            sequence += 1
-                            pending_section = None
-                        line_vals = line._prepare_account_move_line()
+                if line.display_type == 'line_section':
+                    pending_section = line
+                    continue
+                if line not in lines_to_invoice:
+                    continue
+                if not float_is_zero(line.qty_to_invoice,
+                                     precision_digits=precision):
+                    if pending_section:
+                        line_vals = (
+                            pending_section._prepare_account_move_line())
                         line_vals.update({'sequence': sequence})
                         invoice_vals['invoice_line_ids'].append(
                             (0, 0, line_vals))
                         sequence += 1
-                else:
-                    line.is_product_select = True
+                        pending_section = None
+                    line_vals = line._prepare_account_move_line()
+                    line_vals.update({'sequence': sequence})
+                    invoice_vals['invoice_line_ids'].append(
+                        (0, 0, line_vals))
+                    sequence += 1
             invoice_vals_list.append(invoice_vals)
         if not invoice_vals_list:
             raise UserError(_('There is no invoice-able line. If a product has'
@@ -124,6 +128,7 @@ class PurchaseOrder(models.Model):
         # is actually negative or not
         moves.filtered(lambda m: m.currency_id.round(m.amount_total) < 0) \
             .action_switch_invoice_into_refund_credit_note()
+        self.order_line.write({'is_product_select': False})
         return self.action_view_invoice(moves)
 
 

--- a/invoice_bill_for_selected_order_lines/views/purchase_order_views.xml
+++ b/invoice_bill_for_selected_order_lines/views/purchase_order_views.xml
@@ -12,7 +12,7 @@
                    position="before">
                 <field name="qty_to_invoice" invisible="1"/>
                 <field name="is_product_select" nolabel="1"
-                       attrs="{'invisible': [('qty_to_invoice', '!=', 1)]}"/>
+                       attrs="{'invisible': [('qty_to_invoice', '&lt;=', 0)]}"/>
             </xpath>
             <xpath expr="//field[@name='order_line']" position="before">
                 <div style="display: flex; flex-direction: row; margin: 10px;">

--- a/invoice_bill_for_selected_order_lines/views/sale_order_views.xml
+++ b/invoice_bill_for_selected_order_lines/views/sale_order_views.xml
@@ -11,7 +11,7 @@
             <xpath expr="//field[@name='order_line']/tree/field[@name='product_id']"
                    position="before">
                 <field name="is_product_select" nolabel="1"
-                       attrs="{'invisible': [('qty_to_invoice', '!=', 1)]}"/>
+                       attrs="{'invisible': [('qty_to_invoice', '&lt;=', 0)]}"/>
             </xpath>
             <xpath expr="//field[@name='order_line']" position="before">
                 <div style="display: flex; flex-direction: row; margin: 10px;">


### PR DESCRIPTION
## Problem

Purchase and sale order lines could only be selected when
`qty_to_invoice` was exactly 1.

Additionally, creating a partial vendor bill incorrectly selected
the remaining purchase order lines, causing subsequent bills to
include unintended products.

## Solution

- Display the selection checkbox for every line with a positive
  quantity to invoice.
- Generate vendor bills only from the selected invoiceable lines.
- Preserve unselected purchase order lines.
- Clear the selection after successfully creating the vendor bill.
- Bump the module version to 15.0.1.0.1.

## Testing

- Updated the module successfully on Odoo 15.
- Verified XML and Python syntax.
- Tested with a purchase order containing hundreds of lines and
  partial vendor bills.